### PR TITLE
Makefile: add -O compiler optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ DEFINES ?= DEBUG
 
 OUTDIR ?= build
 
+CCFLAGS += "-O"
+
 .PHONY:all
 all:$(OUTDIR)/smart-doorbell
 


### PR DESCRIPTION
fixes:
warning _FORTIFY_SOURCE requires compiling with optimization (-O)